### PR TITLE
Increase node_ops_meta_data watchdog interval to fit with large clusters

### DIFF
--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -122,7 +122,7 @@ class node_ops_meta_data {
     std::function<void ()> _signal;
     shared_ptr<node_ops_info> _ops;
     seastar::timer<lowres_clock> _watchdog;
-    std::chrono::seconds _watchdog_interval{30};
+    std::chrono::seconds _watchdog_interval{300};
     bool _aborted = false;
 public:
     explicit node_ops_meta_data(


### PR DESCRIPTION
On large cluster (70 nodes), new nodes are unable to join cluster.
Bootstrap phase always fails with error:
storage_service - node_ops_cmd_check: Node <ip_of_boostrapping_node> rejected node_ops_cmd=18 from node=<ip_of_boostrapping_node> with ops_uuid=bf8db550-f268-4ff2-8807-be09c190d47c, pending_node_ops={}, the node ops is unknown

In storage_service::run_bootstrap_ops(), time spent to send node_ops_cmd::bootstrap_prepare
to all nodes in clusters can take more than 30s on large cluster.