### PR TITLE
rest_authenticator: fix two issues with seastar http client

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "seastar"]
 	path = seastar
-	url = https://github.com/scylladb/scylla-seastar
+	url = https://github.com/criteo-forks/scylla-seastar
+	pushurl = git@github.com:criteo-forks/scylla-seastar.git
 	ignore = dirty
 [submodule "swagger-ui"]
 	path = swagger-ui

--- a/docs/dev/rest_authc_authz.md
+++ b/docs/dev/rest_authc_authz.md
@@ -62,12 +62,14 @@ $ ./tools/toolchain/dbuild ./build/release/scylla --workdir tmp --smp 2 --devel
 Run FastAPI rest server
 
 ```bash
-$ ./tools/rest_authenticator_server/rest_server.sh
+$ cd tools/rest_authenticator_server
+$ ./rest_server.sh
 ```
 
 Run Test client
 
 ```bash
+$ cd tools/rest_authenticator_server
 $ ./tools/rest_authenticator_server/scylla_client.sh
 ```
 

--- a/test/boost/rest_authenticator_test.cc
+++ b/test/boost/rest_authenticator_test.cc
@@ -37,7 +37,7 @@ using namespace seastar::testing;
 //
 // Notes:
 // to execute test suite, run ./tools/toolchain/dbuild ./test.py --no-parallel-cases --mode debug rest_authenticator
-// to execute a specific test case, run /tools/toolchain/dbuild build/debug/test/boost/rest_authenticator_test --run_test=<test_case>
+// to execute a specific test case, run ./tools/toolchain/dbuild build/debug/test/boost/rest_authenticator_test --run_test=<test_case>
 //
 
 cql_test_config rest_authenticator_on(int port, bool use_outdated_certs) {

--- a/tools/rest_authenticator_server/client.py
+++ b/tools/rest_authenticator_server/client.py
@@ -28,7 +28,7 @@ from cassandra.auth import PlainTextAuthProvider
 def contact_scylla(username='scylla_user', password='not_cassandra'):
     print(f'Run with user {username}')
     auth_provider = PlainTextAuthProvider(username=username, password=password)
-    cluster = Cluster(auth_provider=auth_provider, protocol_version=2)
+    cluster = Cluster(auth_provider=auth_provider, protocol_version=3)
     session = cluster.connect()
     try:
         print('roles')

--- a/tools/rest_authenticator_server/rest_server.sh
+++ b/tools/rest_authenticator_server/rest_server.sh
@@ -20,11 +20,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Scylla.  If not, see <http://www.gnu.org/licenses/>.
 #
-
-deactivate
 python3 -m venv --clear venv
 source venv/bin/activate
 pip3 install -r requirements.txt
 
 echo "Start Rest Api Serevr"
-uvicorn main:app --reload --port 8000 --ssl-keyfile certs/rest_api.key --ssl-certfile certs/rest_api.crt 
+uvicorn main:app --reload --port 8000 --ssl-keyfile certs/rest_api.key --ssl-certfile certs/rest_api.crt


### PR DESCRIPTION
* Forked scylla-seastar submodule to patch two bugs on seastar http client that can't be workarounded without fixing seastar.

* 1st bug: closure of faulty http connections generate unchecked exceptional futures, making unit test to fail (cf. expired_tls_certs test in rest_authenticator_test suite). Issue reported upstream https://github.com/scylladb/seastar/pull/1776.

* 2nd bug: current seastar http client doesn't support http response headers in lower case, preventing deserialization of response from our python rest_auth_endpoint (content-length header isn't found by seastar to determine length of response stream). Issue is already fixed in a recent version of seastar but not available for scylla-5.2.4. See https://github.com/scylladb/seastar/commit/58f97fc5b3a492952780c35ae53dfc547f77f815