### PR TITLE
make our rest_authenticator accepted by some clients

### DIFF
--- a/auth/rest_authenticator.cc
+++ b/auth/rest_authenticator.cc
@@ -62,8 +62,8 @@ namespace roles_valid_table {
 }
 }
 
-constexpr std::string_view
-rest_authenticator_name("com.criteo.scylladb.auth.RestAuthenticator");
+constexpr std::string_view cassandra_authenticator_name("org.apache.cassandra.auth.PasswordAuthenticator");
+constexpr std::string_view rest_authenticator_name("com.criteo.scylladb.auth.RestAuthenticator");
 
 // name of the hash column.
 static constexpr std::string_view SALTED_HASH = "salted_hash";
@@ -208,7 +208,7 @@ db::consistency_level rest_authenticator::consistency_for_user(std::string_view 
 }
 
 std::string_view rest_authenticator::qualified_java_name() const {
-    return rest_authenticator_name;
+    return cassandra_authenticator_name;
 }
 
 bool rest_authenticator::require_authentication() const {

--- a/test/boost/rest_authenticator_test.cc
+++ b/test/boost/rest_authenticator_test.cc
@@ -255,7 +255,7 @@ static future<> create_superuser_role(cql3::query_processor &qp) {
 SEASTAR_TEST_CASE(rest_authenticator_conf) {
     return with_dummy_authentication_server([] (cql_test_env &env) {
         auto &a = env.local_auth_service().underlying_authenticator();
-        BOOST_REQUIRE_EQUAL(a.qualified_java_name(), "com.criteo.scylladb.auth.RestAuthenticator");
+        BOOST_REQUIRE_EQUAL(a.qualified_java_name(), "org.apache.cassandra.auth.PasswordAuthenticator");
         BOOST_REQUIRE(a.require_authentication());
 
         auto &authenticator_config = a.get_authenticator_config();


### PR DESCRIPTION
authenticator_name is checked by some clients (go, rust) and connections are rejected if not in an allowed list on client side. We spoof cassandra authenticator name as scylla is doing for password authenticator.